### PR TITLE
Handle ongoing work experience dates

### DIFF
--- a/src/components/ThemeContext.ts
+++ b/src/components/ThemeContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface ThemeContextType {
+  theme: string;
+  setTheme: (theme: string) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,26 +1,16 @@
-// src/components/ThemeProvider.tsx
-'use client'; // <-- บอก Next.js ว่านี่คือ Client Component
+'use client';
 
-import { createContext, useContext, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
+import { ThemeContext } from './ThemeContext';
 
-// สร้าง Context สำหรับ Theme
-interface ThemeContextType {
-  theme: string;
-  setTheme: (theme: string) => void;
-}
-
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-
-// สร้าง Provider Component
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState('light'); // default theme
+  const [theme, setThemeState] = useState('light');
 
-  // Effect นี้จะทำงานเฉพาะบน Client เท่านั้น
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme');
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    
+
     if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
       setTheme('dark');
     } else {
@@ -46,11 +36,3 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-// สร้าง Custom Hook เพื่อให้เรียกใช้ง่าย
-export function useTheme() {
-  const context = useContext(ThemeContext);
-  if (context === undefined) {
-    throw new Error('useTheme must be used within a ThemeProvider');
-  }
-  return context;
-}

--- a/src/components/useTheme.ts
+++ b/src/components/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ThemeContext } from './ThemeContext';
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -107,15 +107,20 @@ function ExperienceSection() {
         Previously
       </h2>
       <div className="flex flex-col gap-3">
-        {profileData.work_experience.map((exp, index) => (
-          <ExperienceItem 
-            key={index} 
-            year={`${new Date(exp.start_date).getFullYear()}-${new Date(exp.end_date).getFullYear()}`}
-            role={exp.role} 
-            company={exp.company} 
-            link={exp.link}
-          />
-        ))}
+        {profileData.work_experience.map((exp, index) => {
+          const startYear = new Date(exp.start_date).getFullYear();
+          const endDate = new Date(exp.end_date);
+          const endYear = isNaN(endDate.getFullYear()) ? 'Present' : endDate.getFullYear();
+          return (
+            <ExperienceItem
+              key={index}
+              year={`${startYear}-${endYear}`}
+              role={exp.role}
+              company={exp.company}
+              link={exp.link}
+            />
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix work experience year range to show "Present" when end date isn't a real date
- refactor theme provider by separating context and hook to satisfy lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896feb42930832b854079d879a6367d